### PR TITLE
Improve parsing error message

### DIFF
--- a/yaml.el
+++ b/yaml.el
@@ -969,9 +969,9 @@ value.  It defaults to the symbol :false."
                  (yaml--top))))
 
       (when (< yaml--parsing-position (length yaml--parsing-input))
-        (error (format "parser finished before end of input %s/%s"
-                       yaml--parsing-position
-                       (length yaml--parsing-input))))
+        (error "Unable to parse YAML stream.  Parser finished before end of input %s/%s"
+               yaml--parsing-position
+               (length yaml--parsing-input)))
       (when yaml--parse-debug (message "Parsed data: %s" (pp-to-string res)))
       (yaml--walk-events res)
       (if (zerop (hash-table-count yaml--anchor-mappings))


### PR DESCRIPTION
Change the wording of the error message to clearly indicate a parsing error.