### PR TITLE
Add yaml-encode feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 yaml.el is a YAML parser written in Emacs List without any external
 dependencies.  It provides an interface similar to the Emacs JSON
-parsing utility.  The function provided is as follows:
+parsing utility.  The functions provided are as follows:
 
 ``` emacs-lisp
 (yaml-parse-string string &rest args)
@@ -14,7 +14,7 @@ The following keyword args are accepted:
   objects data in.  It takes the following symbols:
   - `hash-table` (default)
   - `alist`
-  - `plist`
+n  - `plist`
 - `:sequence-type` specifies the Lisp data structure to store the
   parsed sequences in.  It takes the following symbols:
   - `array` (default)
@@ -23,6 +23,13 @@ The following keyword args are accepted:
   to the symbol `:null`.
 - `:false-object` specifies the lisp object to use for false.
   Defaults to the symbol `:false`.
+
+```emacs-lisp
+(yaml-encode object)
+```
+
+The function `yaml-encode` will encode a Lisp object to a YAML string.
+
 
 ## Installation
 
@@ -56,9 +63,20 @@ translations:
   three: үш")
 
 ;; => #s(hash-table ... data ("translations" #s(hash-table ...)))
+
+
+(yaml-encode '("omitted" ((count . 3) (value . 10) (items ("ruby" "diamond"))) "omitted"))
+
+;; => "
+- omitted
+- count: 3
+  value: 10
+  items:
+    ruby: [diamond]
+- omitted"
+
+
 ```
-
-
 
 ## Caveats
 

--- a/yaml-tests.el
+++ b/yaml-tests.el
@@ -456,6 +456,57 @@ keep: |+
 # beep" :object-type 'alist)))
 
 
+(defun yaml-test-round-trip (o)
+  "Test (equal (decode (encode o)) o)"
+  (let* ((encoded (yaml-encode o))
+         (parsed (yaml-parse-string encoded
+                                    :object-type 'alist
+                                    :sequence-type 'list))
+         (encoded-2 (yaml-encode o)))
+    (equal encoded encoded-2)))
+
+(ert-deftest yaml-encode-tests ()
+  (should (yaml-test-round-trip 1))
+  (should (yaml-test-round-trip "one"))
+  (should (yaml-test-round-trip nil))
+  (should (yaml-test-round-trip '(1 2 3)))
+  (should (yaml-test-round-trip '((1 . 2) (3 . 4) (5 . 6))))
+  (should (yaml-test-round-trip
+           '(("key" . "value")
+             ("nested-map" . ((1 . 2) (3 . 4) (5 . 6))))))
+  (should (yaml-test-round-trip
+           '("one"
+             (("key" . "value")
+              ("nested-map" . ((1 . 2) (3 . 4) (5 . 6))))
+             "three")))
+  (should (yaml-test-round-trip
+           '("one"
+             (("key" . "value")
+              ("nested-map" . ((1 . 2) (3 . 4) (5 . 6))))
+             "three")))
+  (should (yaml-test-round-trip
+           '("one"
+             (("key" . "value")
+              ("nested-map" . ((1 . 2) (3 . 4) (5 . 6))))
+             ("nested" "list" 1 2 3))))
+  (should (yaml-test-round-trip
+           '("one"
+             (("key" . "value")
+              ("nested-map" . ((1 . 2) (3 . 4) (5 . 6)))
+              ("nested-list" . (1 2 3 4 5)))
+             ("nested" "list" 1 2 3))))
+  (should (yaml-test-round-trip
+           '("one"
+             (("key" . "value")
+              ("nested-map" . ((1 . 2) (3 . 4) (5 . 6)))
+              ("nested-list" . (1 2 3 4 5)))
+             ("nested" "list" 1 2 3))))
+  (should (yaml-test-round-trip
+           '(t nil)))
+  (should (yaml-encode
+           '((("aaaa" "bbbb" "cccc") ("dddd" "eeee" "ffff") ("gggg" "hhhh" "iiii"))
+             ("jjjj" "kkkk" "llll") ("mmmm" "nnnn" "oooo") ("pppp" "qqqq" "rrrr")))))
+
 (provide 'yaml-tests)
 
 ;; yaml-tests.el ends here


### PR DESCRIPTION
This PR addresses issue #6 by adding a new function called `yaml-encode` which returns a YAML string representing a Lisp object.