### PR TITLE
FIX insert symbol name when not equal to :null or :false

### DIFF
--- a/yaml.el
+++ b/yaml.el
@@ -2417,7 +2417,7 @@ auto-detecting the indentation.  Functionality defers to
     (cond
      ((eql s :null) (insert "null"))
      ((eql s :false) (insert "false"))
-     (t (insert t))))
+     (t (insert (symbol-name s)))))
    ((numberp s) (insert (number-to-string s)))
    ((stringp s)
     (if (string-match "\\`[-_a-zA-Z0-9]+\\'" s)


### PR DESCRIPTION
This fixes a bug I came across when experimenting with another project depending on this library. I was getting a "Wrong type argument" error when encoding an object with :object-key-type set to 'symbol. Digging around it looked like the bug was introduced by  a type-o in 64c117d0847c57b27133ffeefa4d77cfcec288e9:

```
(defun yaml--encode-scalar (s)
  "Encode scalar S to buffer."
  (cond
   ((not s) (insert "null"))
   ((eql t s) (insert "true"))
   ((symbolp s)
    (cond
     ((eql s :null) (insert "null"))
     ((eql s :false) (insert "false"))
     (t (insert t)))) ; Should be -> (t (insert (symbol-name s)))))
   ((numberp s) (insert (number-to-string s)))
   ((stringp s)
    (if (string-match "\\`[-_a-zA-Z0-9]+\\'" s)
        (insert s)
      (insert "\"" (yaml--encode-escape-string s) "\"")))))
```