### PR TITLE
Fix empty single quote string bug

### DIFF
--- a/yaml-tests.el
+++ b/yaml-tests.el
@@ -341,7 +341,10 @@ key-2: |2-
                                     :object-key-type 'string
                                     :object-type 'alist)
                  '(("key-1" . "  ---\n  ---")
-                   ("key-2" . "  ---\n  ---")))))
+                   ("key-2" . "  ---\n  ---"))))
+  (should (equal (yaml-parse-string "''") ""))
+  (should (equal (yaml-parse-string "foo: ''" :object-type 'alist)
+                 '((foo . "")))))
 
 
 (ert-deftest yaml-parsing-completes ()

--- a/yaml.el
+++ b/yaml.el
@@ -581,13 +581,15 @@ reverse order."
                                (substring x 1)
                              " "))
                          replaced))
-              (replaced (replace-regexp-in-string
-                         "''"
-                         (lambda (x)
-                           (if (> (length x) 1)
-                               (substring x 1)
-                             "'"))
-                         replaced)))
+              (replaced (if (not (equal "''" replaced))
+                            (replace-regexp-in-string
+                             "''"
+                             (lambda (x)
+                               (if (> (length x) 1)
+                                   (substring x 1)
+                                 "'"))
+                             replaced)
+                          replaced)))
          (yaml--scalar-event "single"
                              (substring replaced 1 (1- (length replaced)))))))
     ("c-double-quoted" .


### PR DESCRIPTION
Fixes #26 

The bug was due to the particularity that in a single quoted string, a single quote escapes a single quote.