### PR TITLE
Fix the anchor parse event turning maps into lists

### DIFF
--- a/yaml-tests.el
+++ b/yaml-tests.el
@@ -344,7 +344,20 @@ key-2: |2-
                    ("key-2" . "  ---\n  ---"))))
   (should (equal (yaml-parse-string "''") ""))
   (should (equal (yaml-parse-string "foo: ''" :object-type 'alist)
-                 '((foo . "")))))
+                 '((foo . ""))))
+  ;; anchor should produce same parse as without anchor
+  (should (equal (yaml-parse-string "bill-to:  &id001
+    city:   East Centerville
+    state:  KS
+" :object-type 'alist
+  :object-key-type 'string
+  :string-values t)
+                 (yaml-parse-string "bill-to:
+    city:   East Centerville
+    state:  KS
+" :object-type 'alist
+  :object-key-type 'string
+  :string-values t))))
 
 
 (ert-deftest yaml-parsing-completes ()


### PR DESCRIPTION
The anchor event, when parsing mapping as alists, ends up turning the mapping into a list.

```lisp
(yaml-parse-string "bill-to:  &id001
    city:   East Centerville
    state:  KS
" :object-type 'alist
:object-key-type 'string
:string-values t)
```
Resulted in: `(("bill-to" . [("city" . "East Centerville") ("state" . "KS")]))` 
as opposed to `(("bill-to" . (("city" . "East Centerville") ("state" . "KS"))))`