### PR TITLE
Fix string values state bug

### DIFF
--- a/yaml-tests.el
+++ b/yaml-tests.el
@@ -386,7 +386,11 @@ ship-to:
 
 " :object-type 'alist
   :object-key-type 'string
-  :string-values t))))
+  :string-values t)))
+  (should (equal (progn
+                   (yaml-parse-string-with-pos "- # Empty\n- abc")
+                   (yaml-parse-string "- # Empty\n- abc"))
+                 [:null "abc"])))
 
 
 (ert-deftest yaml-parsing-completes ()

--- a/yaml.el
+++ b/yaml.el
@@ -1064,8 +1064,9 @@ then check EXPR at the current position."
      ((equal 'list sequence-type)
       (setq yaml--parsing-sequence-type 'list))
      (t (error "Invalid sequence-type.  sequence-type must be list or array")))
-    (when string-values
-      (setq yaml--string-values t))))
+    (if string-values
+        (setq yaml--string-values t)
+      (setq yaml--string-values nil))))
 
 (defun yaml-parse-string (string &rest args)
   "Parse the YAML value in STRING.  Keyword ARGS are as follows:

--- a/yaml.el
+++ b/yaml.el
@@ -1115,7 +1115,10 @@ value.  It defaults to the symbol :false."
     res))
 
 (defun yaml-parse-string-with-pos (string)
-  "Parse the YAML value in STRING, storing positions as text properties."
+  "Parse the YAML value in STRING, storing positions as text properties.
+
+NOTE: This is an experimental feature and may experience API
+changes in the future."
   (let ((yaml--parsing-store-position t))
     (yaml-parse-string string
                        :object-type 'alist


### PR DESCRIPTION
There is a bug that when the string values flag is used, it isn't getting reset in the case that it's not on.

I plan on refactoring the parsing settings to use dynamic-scope vs setting the variables before the run to make it less error prone.