### PR TITLE
Don't remove all properties, just yaml-n

### DIFF
--- a/yaml.el
+++ b/yaml.el
@@ -3,7 +3,7 @@
 ;; Copyright © 2021 Zachary Romero <zkry@posteo.org>
 
 ;; Author: Zachary Romero <zkry@posteo.org>
-;; Version: 0.5.0
+;; Version: 0.5.1
 ;; Homepage: https://github.com/zkry/yaml.el
 ;; Package-Requires: ((emacs "25.1"))
 ;; Keywords: tools
@@ -45,7 +45,7 @@
 (require 'seq)
 (require 'cl-lib)
 
-(defconst yaml-parser-version "0.5.0")
+(defconst yaml-parser-version "0.5.1")
 
 (defvar yaml--parse-debug nil
   "Turn on debugging messages when parsing YAML when non-nil.

--- a/yaml.el
+++ b/yaml.el
@@ -261,7 +261,7 @@ This flag is intended for development purposes.")
 (defun yaml--process-literal-text (text)
   "Remove the header line for a folded match and return TEXT body formatted."
   (let ((n (get-text-property 0 'yaml-n text)))
-    (setq text (substring-no-properties text 0 (length text)))
+    (remove-text-properties 0 (length text) '(yaml-n nil) text)
     (let* ((header-line (substring text 0 (string-match "\n" text)))
            (text-body (substring text (1+ (string-match "\n" text))))
            (parsed-header (yaml--parse-block-header header-line))


### PR DESCRIPTION
This bug fixes a bug that effects the yaml-pro integration (as it relies on some of the text properties existing).