### PR TITLE
Update docstring and README to match current behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ The following keyword args are accepted:
   - `alist`
   - `plist`
 - `:object-key-type` specifies how map keys should be handled. It takes the following symbols:
-  - `string` (default)
-  - `symbol` keys of maps will be converted to symbols. Not that this matches the behavior of the JSON parser.
+  - `string`
+  - `symbol` (default) Use symbols as keys.  If `:object-type` is `plist`, this becomes the same as `keyword`.
+  - `keyword` Always use keywords as keys.
 - `:sequence-type` specifies the Lisp data structure to store the
   parsed sequences in.  It takes the following symbols:
   - `array` (default)

--- a/yaml.el
+++ b/yaml.el
@@ -1084,16 +1084,23 @@ then check EXPR at the current position."
 
 OBJECT-TYPE specifies the Lisp object to use for representing
 key-value YAML mappings.  Possible values for OBJECT-TYPE are
-the symbols hash-table, alist, and plist.
+the symbols `hash-table' (default), `alist', and `plist'.
 
-SEQUENCE-TYPE specifies the Lisp object to use for representing YAML
-sequences.   Possible values for SEQUENCE-TYPE are the symbols list, and array.
+OBJECT-KEY-TYPE specifies the Lisp type to use for keys in
+key-value YAML mappings.  Possible values are the symbols
+`string', `symbol', and `keyword'.  By default, this is `symbol';
+if OBJECT-TYPE is `plist', the default is `keyword' (and `symbol'
+becomes synonym for `keyword').
+
+SEQUENCE-TYPE specifies the Lisp object to use for representing
+YAML sequences.  Possible values for SEQUENCE-TYPE are the symbols
+`list', and `array' (default).
 
 NULL-OBJECT contains the object used to represent the null value.
-It defaults to the symbol :null.
+It defaults to the symbol `:null'.
 
 FALSE-OBJECT contains the object used to represent the false
-value.  It defaults to the symbol :false."
+value.  It defaults to the symbol `:false'."
   (yaml--initialize-parsing-state args)
   (let ((res (yaml--parse string
                (yaml--top))))


### PR DESCRIPTION
README currently claims:

> `:object-key-type` specifies how map keys should be handled. It takes the following symbols:
> - `string` (default)
> - `symbol` keys of maps will be converted to symbols. Not that this matches the behavior of the JSON parser.

which does not match current behavior:

https://github.com/zkry/yaml.el/blob/0ac7f365bb6b4507259b31679bb37ac291e1f1c7/yaml.el#L1060-L1070

(`yaml-parse-string`'s docstring currently doesn't mention `:object-key-type`.)

This PR updates README and the documentation of `yaml-parse-string` to match current behavior.
