### PR TITLE
yaml--the-end: fix incorrect regexp

### DIFF
--- a/yaml.el
+++ b/yaml.el
@@ -932,7 +932,7 @@ This is currently unimplemented."
       (and (yaml--state-curr-doc)
            (yaml--start-of-line)
            (string-match
-            "\\^g(?:---|\\.\\.\\.\\)\\([[:blank:]]\\|$\\)"
+            "\\^g\\(?:---|\\.\\.\\.\\)\\([[:blank:]]\\|$\\)"
             (substring yaml--parsing-input yaml--parsing-position)))))
 
 (defun yaml--ord (f)


### PR DESCRIPTION
`yaml--the-end` was matching against

- a literal `^g`
- an optional literal `(`
- a literal `:`
- etc.

The optional literal `(` is probably supposed to be the start of an unnamed group `\\(?:`.