### PR TITLE
Correctly encode empty arrays

### DIFF
--- a/yaml-tests.el
+++ b/yaml-tests.el
@@ -558,7 +558,12 @@ keep: |+
          (encoded-2 (yaml-encode o)))
     (equal encoded encoded-2)))
 
+
 (ert-deftest yaml-encode-tests ()
+  (should (equal (let* ((ht (make-hash-table :test #'equal)))
+                   (puthash 'input-files [] ht)
+                   (yaml-encode ht))
+                 "input-files: []"))
   (should (yaml-test-round-trip 1))
   (should (yaml-test-round-trip "one"))
   (should (yaml-test-round-trip nil))

--- a/yaml.el
+++ b/yaml.el
@@ -2629,9 +2629,11 @@ without first inserting a newline."
 If AUTO-INDENT is non-nil, start the list on the current line,
 auto-detecting the indentation.  Functionality defers to
 `yaml--encode-list'."
-  (yaml--encode-list (seq-map #'identity a)
-                     indent
-                     auto-indent))
+  (if (equal a [])
+      (insert "[]")
+    (yaml--encode-list (seq-map #'identity a)
+                       indent
+                       auto-indent)))
 
 
 (defun yaml--encode-scalar (s)


### PR DESCRIPTION
Fixes #62 

This PR modifies the encoding of arrays so that if the array is empty, it immediately encodes it as `[]`.