### PR TITLE
Silence unused-variable byte-compile warnings; widen CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,35 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
-    - uses: purcell/setup-emacs@master
-      with:
-        version: 27.2
-    - uses: actions/checkout@v2
-    - name: Run tests
-      run: |
-        emacs -Q --batch -L . -l *-tests.el -f ert-run-tests-batch-and-exit
+      - uses: actions/checkout@v5
+      - uses: purcell/setup-emacs@master
+        with:
+          version: 27.2
+      - name: Run tests
+        run: |
+          emacs -Q --batch -L . -l *-tests.el \
+            -f ert-run-tests-batch-and-exit
+
+  compile:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Minimum supported (Package-Requires) + latest stable + snapshot.
+        emacs_version:
+          - '25.1'
+          - '30.1'
+          - snapshot
+    steps:
+      - uses: actions/checkout@v5
+      - uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs_version }}
+      - name: Byte-compile (warnings as errors)
+        run: |
+          emacs -Q --batch -L . \
+            --eval '(setq byte-compile-error-on-warn t)' \
+            -f batch-byte-compile yaml.el yaml-tests.el

--- a/yaml-tests.el
+++ b/yaml-tests.el
@@ -496,7 +496,7 @@ foo: bar
 - [ {JSON: like}:adjacent ]"))
 
   ;; example 7.22
-  (should (not (condition-case n
+  (should (not (condition-case nil
                    (yaml-parse-string "[ foo
  bar: invalid,
  \"foo...>1K characters...bar\": invalid ]")
@@ -552,7 +552,7 @@ keep: |+
 (defun yaml-test-round-trip (o)
   "Test (equal (decode (encode o)) o)"
   (let* ((encoded (yaml-encode o))
-         (parsed (yaml-parse-string encoded
+         (_parsed (yaml-parse-string encoded
 					                :object-type 'alist
 					                :sequence-type 'list))
          (encoded-2 (yaml-encode o)))


### PR DESCRIPTION
## What

Two `Unused lexical variable` byte-compile warnings in `yaml-tests.el`,
plus a CI tweak so such warnings are caught going forward.

## Changes

**Fix (commit 1).**
- The `condition-case` error variable `n` (example 7.22) is never used
  in the handler, so it is dropped (`condition-case nil`).
- `parsed` in `yaml-test-round-trip` is bound but unused; renamed to
  `_parsed` to mark it intentionally unused while still exercising the
  parse call.

**CI (commit 2).** The workflow only ran tests on Emacs 27.2. Added a
compile job that byte-compiles with warnings treated as errors on the
minimum supported Emacs (25.1), the latest stable (30.1), and the
development snapshot. Bumped `actions/checkout` to v5 and added
dependabot for the actions. The existing 27.2 test job is unchanged.

## Verification

All CI jobs pass:
https://github.com/dannywillems/yaml.el/actions